### PR TITLE
RSDK-11206 - Pin libcamera dep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ dep:
 		cd ${HOME}/opt/src && \
 		git clone https://github.com/raspberrypi/libcamera.git && \
 		cd libcamera && \
+		git checkout d83ff0a4 && \
 		meson setup build --prefix=/usr && \
 		ninja -C build install && \
 		rm -rf ${HOME}/opt/src/libcamera; \

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ dep:
 		cd ${HOME}/opt/src && \
 		git clone https://github.com/raspberrypi/libcamera.git && \
 		cd libcamera && \
-		git checkout d83ff0a4 && \
+		git checkout v0.5.0+rpt20250429 && \
 		meson setup build --prefix=/usr && \
 		ninja -C build install && \
 		rm -rf ${HOME}/opt/src/libcamera; \

--- a/constraints.h
+++ b/constraints.h
@@ -32,6 +32,6 @@
 // Pi
 #define PI_API_SUBTYPE "csi-pi"
 #define PI_INPUT_SOURCE "libcamerasrc"
-#define PI_INPUT_FORMAT "video/x-raw"
+#define PI_INPUT_FORMAT "video/x-raw,format=NV12"
 #define PI_VIDEO_CONVERTER "videoconvert"
 #define PI_OUTPUT_ENCODER "jpegenc"


### PR DESCRIPTION
## Description

Our build pipeline did not checkpoint the `libcamera` dependency commit. New builds were no longer working on Pi5s

This PR just pins the libcamera to the version that currently ships on device and updates the gstreamer pipeline for newer API.

```
viam@av-pi-5:~ $ libcamera-hello --version
rpicam-apps build: v1.7.0 5a3f5965aca9 30-04-2025 (11:42:35)
rpicam-apps capabilites: egl:1 qt:1 drm:1 libav:1
libcamera build: v0.5.0+59-d83ff0a4
```

```
libcamerasrc ! video/x-raw,format=NV12,width=1920,height=1080,framerate=30/1 \
            ! videoconvert ! jpegenc ! appsink …
```

## Testing
All tests performed with IMX219 camera
- Pi4 beye ✅ 
- Pi4 bworm ✅ 
- Pi5 bworm ✅ 
- Jetson orin-nano ✅ 

## Refs
- [libcamera release](https://github.com/raspberrypi/libcamera/releases/tag/v0.5.0%2Brpt20250429)
- [NV12 Pixel Format](https://paulbourke.net/dataformats/nv12/)
  - Just yuv420 but with the UV planes interleaved
