### PR TITLE
Cache latest frame to support multiple concurrent consumers

### DIFF
--- a/csi_camera.cpp
+++ b/csi_camera.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <chrono>
 #include <cstring>
 #include <fstream>
@@ -52,18 +53,19 @@ void CSICamera::set_attr(const ProtoStruct& attrs, const std::string& name, T CS
 }
 
 Camera::image_collection CSICamera::get_images(std::vector<std::string> /* filter_source_names */, const ProtoStruct& /* extra */) {
+    auto frame = get_latest_frame();
+
     raw_image image;
     image.mime_type = DEFAULT_OUTPUT_MIMETYPE;
-    image.bytes = get_csi_image();
+    image.bytes = *frame.bytes;
     if (image.bytes.empty()) {
-        throw Exception("no bytes retrieved from get_csi_image");
+        throw Exception("no bytes retrieved from latest frame");
     }
     image.source_name = "";
 
     image_collection collection;
     collection.images = std::vector<raw_image>{std::move(image)};
-    auto now = std::chrono::system_clock::now();
-    auto duration_since_epoch = now.time_since_epoch();
+    auto duration_since_epoch = frame.captured_at.time_since_epoch();
     auto nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(duration_since_epoch);
     collection.metadata.captured_at = std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>(nanoseconds);
 
@@ -113,6 +115,11 @@ void CSICamera::init_csi(const std::string pipeline_args) {
         gst_object_unref(pipeline);
         throw Exception("Failed to get the appsink element");
     }
+
+    // Store every frame in the latest-frame cache as it arrives, so that
+    // concurrent consumers read the cache instead of competing for samples
+    g_object_set(G_OBJECT(appsink), "emit-signals", TRUE, nullptr);
+    g_signal_connect(appsink, "new-sample", G_CALLBACK(&CSICamera::on_new_sample), this);
 
     // Start the pipeline
     if (gst_element_set_state(pipeline, GST_STATE_PLAYING) == GST_STATE_CHANGE_FAILURE) {
@@ -249,23 +256,49 @@ void CSICamera::catch_pipeline(GstMessage* msg) {
         g_free(debugInfo);
 }
 
-std::vector<unsigned char> CSICamera::get_csi_image() {
-    // Pull sample from appsink
-    std::vector<unsigned char> vec;
+GstFlowReturn CSICamera::on_new_sample(GstAppSink* /* sink */, gpointer user_data) {
+    return static_cast<CSICamera*>(user_data)->handle_new_sample();
+}
+
+GstFlowReturn CSICamera::handle_new_sample() {
     GstSample* sample = gst_app_sink_pull_sample(GST_APP_SINK(appsink));
-    if (sample != nullptr) {
-        // Retrieve buffer from the sample
-        GstBuffer* buffer = gst_sample_get_buffer(sample);
+    if (sample == nullptr) {
+        // appsink is flushing or reached EOS
+        return GST_FLOW_OK;
+    }
 
-        // Process or handle the buffer as needed
-        if (buffer != nullptr) {
-            vec = buff_to_vec(buffer);
-        } else {
-            VIAM_RESOURCE_LOG(warn) << "Failed to get buffer from sample";
+    GstBuffer* buffer = gst_sample_get_buffer(sample);
+    if (buffer != nullptr) {
+        // Must not throw across the GStreamer C callback boundary
+        try {
+            auto bytes = std::make_shared<const std::vector<unsigned char>>(buff_to_vec(buffer));
+            {
+                std::lock_guard<std::mutex> lock(frame_mutex);
+                latest_frame = std::move(bytes);
+                latest_frame_time = std::chrono::system_clock::now();
+            }
+            frame_cv.notify_all();
+        } catch (const std::exception& e) {
+            VIAM_RESOURCE_LOG(error) << "Failed to cache frame from appsink: " << e.what();
         }
+    } else {
+        VIAM_RESOURCE_LOG(warn) << "Failed to get buffer from sample";
+    }
 
-        // Release the sample
-        gst_sample_unref(sample);
+    gst_sample_unref(sample);
+    return GST_FLOW_OK;
+}
+
+std::chrono::milliseconds CSICamera::max_frame_age() const {
+    // Frames are expected every 1000/frame_rate ms; tolerate a few missed
+    // intervals before declaring the pipeline stalled, but never less than 1s
+    const int interval_ms = (frame_rate > 0) ? (1000 / frame_rate) : 1000;
+    return std::chrono::milliseconds(std::max(3 * interval_ms, 1000));
+}
+
+CSICamera::cached_frame CSICamera::get_latest_frame() {
+    if (pipeline == nullptr || bus == nullptr) {
+        throw Exception("GST pipeline is not running");
     }
 
     // Check bus for messages
@@ -280,7 +313,27 @@ std::vector<unsigned char> CSICamera::get_csi_image() {
         gst_message_unref(msg);
     }
 
-    return vec;
+    const auto max_age = max_frame_age();
+    std::unique_lock<std::mutex> lock(frame_mutex);
+    if (latest_frame == nullptr) {
+        // No frame has arrived since the pipeline started; give the source
+        // extra time to deliver its first frame
+        const auto first_frame_timeout = std::max(max_age, std::chrono::milliseconds(GST_CHANGE_STATE_TIMEOUT * 1000));
+        if (!frame_cv.wait_for(lock, first_frame_timeout, [this] { return latest_frame != nullptr; })) {
+            throw Exception("timed out waiting for first frame from GST pipeline");
+        }
+    }
+
+    const auto age = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - latest_frame_time);
+    if (age > max_age) {
+        throw Exception("latest frame is stale (" + std::to_string(age.count()) + "ms old): GST pipeline may have stalled");
+    }
+
+    return cached_frame{latest_frame, latest_frame_time};
+}
+
+std::vector<unsigned char> CSICamera::get_csi_image() {
+    return *get_latest_frame().bytes;
 }
 
 std::string CSICamera::create_pipeline() const {

--- a/csi_camera.h
+++ b/csi_camera.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <chrono>
+#include <condition_variable>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -32,6 +35,15 @@ class CSICamera : public viam::sdk::Camera {
     GstBus* bus = nullptr;
     GstElement* appsink = nullptr;
 
+    // Latest-frame cache: written by the GStreamer streaming thread via the
+    // appsink new-sample callback, read concurrently by any number of
+    // get_images callers. Consumers never pull from the appsink themselves,
+    // so one client's request cannot starve another's.
+    std::mutex frame_mutex;
+    std::condition_variable frame_cv;
+    std::shared_ptr<const std::vector<unsigned char>> latest_frame;
+    std::chrono::system_clock::time_point latest_frame_time;
+
    public:
     // Module
     explicit CSICamera(const std::string name, const viam::sdk::ProtoStruct& attrs);
@@ -59,9 +71,20 @@ class CSICamera : public viam::sdk::Camera {
     void catch_pipeline(GstMessage* msg);
 
     // Image
-    // helpers to pull and process images from appsink
+    // helpers to read frames from the latest-frame cache
+    struct cached_frame {
+        std::shared_ptr<const std::vector<unsigned char>> bytes;
+        std::chrono::system_clock::time_point captured_at;
+    };
+    cached_frame get_latest_frame();
+    std::chrono::milliseconds max_frame_age() const;
     std::vector<unsigned char> get_csi_image();
     std::vector<unsigned char> buff_to_vec(GstBuffer* buff);
+
+    // Appsink new-sample callback: invoked on the GStreamer streaming thread
+    // for every frame, stores it in the latest-frame cache
+    static GstFlowReturn on_new_sample(GstAppSink* sink, gpointer user_data);
+    GstFlowReturn handle_new_sample();
 
     // Getters
     int get_width_px() const;

--- a/csi_camera.h
+++ b/csi_camera.h
@@ -37,8 +37,7 @@ class CSICamera : public viam::sdk::Camera {
 
     // Latest-frame cache: written by the GStreamer streaming thread via the
     // appsink new-sample callback, read concurrently by any number of
-    // get_images callers. Consumers never pull from the appsink themselves,
-    // so one client's request cannot starve another's.
+    // get_images callers.
     std::mutex frame_mutex;
     std::condition_variable frame_cv;
     std::shared_ptr<const std::vector<unsigned char>> latest_frame;

--- a/tests/unit/test_csi_camera.cpp
+++ b/tests/unit/test_csi_camera.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
+#include <atomic>
 #include <cstdlib>
+#include <thread>
 #include <viam/sdk/common/instance.hpp>
 #include <viam/sdk/common/proto_convert.hpp>
 #include <viam/sdk/components/camera.hpp>
@@ -52,6 +54,55 @@ TEST(CSICamera, CreateCustom) {
     EXPECT_EQ(camera.get_height_px(), 480);
     EXPECT_EQ(camera.get_frame_rate(), 60);
     EXPECT_EQ(camera.get_video_path(), "1");
+
+    camera.stop_pipeline();
+}
+
+// Test that many concurrent consumers can each get frames: consumers read a
+// shared latest-frame cache, so one client's request does not consume the
+// frame another client is waiting on
+TEST(CSICamera, ConcurrentConsumers) {
+    ensure_runtime();
+
+    ProtoStruct attrs = std::unordered_map<std::string, ProtoValue>();
+    CSICamera camera("test", attrs);
+
+    constexpr int num_consumers = 8;
+    constexpr int images_per_consumer = 5;
+    std::atomic<int> successes{0};
+
+    std::vector<std::thread> consumers;
+    for (int i = 0; i < num_consumers; i++) {
+        consumers.emplace_back([&camera, &successes] {
+            for (int j = 0; j < images_per_consumer; j++) {
+                auto collection = camera.get_images({}, ProtoStruct{});
+                ASSERT_EQ(collection.images.size(), 1);
+                ASSERT_FALSE(collection.images[0].bytes.empty());
+                successes++;
+            }
+        });
+    }
+    for (auto& consumer : consumers) {
+        consumer.join();
+    }
+
+    EXPECT_EQ(successes.load(), num_consumers * images_per_consumer);
+
+    camera.stop_pipeline();
+}
+
+// Test that get_images reports the frame capture time, not the request time
+TEST(CSICamera, CapturedAtIsRecent) {
+    ensure_runtime();
+
+    ProtoStruct attrs = std::unordered_map<std::string, ProtoValue>();
+    CSICamera camera("test", attrs);
+
+    auto collection = camera.get_images({}, ProtoStruct{});
+    auto now = std::chrono::system_clock::now();
+    auto age = std::chrono::duration_cast<std::chrono::milliseconds>(now - collection.metadata.captured_at);
+    EXPECT_GE(age.count(), 0);
+    EXPECT_LE(age.count(), camera.max_frame_age().count());
 
     camera.stop_pipeline();
 }


### PR DESCRIPTION
  Right now `get_images` pulls straight from the appsink, and pulling a sample
  consumes it. So with more than one consumer, whoever asks first takes the
  frame and everyone else sits waiting for the next one — at 1 fps that's seconds of
  waiting per client.

  This changes it so the appsink callback keeps the newest frame in a cache and
  `get_images` just reads from that. Any number of clients can grab the latest
  frame without stealing it from each other. Same approach as realsense and orbbec modules.

- [ ] Not tested on hardware yet.